### PR TITLE
21.12.12 (seungjoo)

### DIFF
--- a/BOJ/bfs/02206-벽_부수고_이동하기/02206-벽_부수고_이동하기-seungjoo.py
+++ b/BOJ/bfs/02206-벽_부수고_이동하기/02206-벽_부수고_이동하기-seungjoo.py
@@ -1,1 +1,34 @@
 # git commit -m "code: Solve boj 02206 벽 부수고 이동하기 (seungjoo)"
+import sys
+input = sys.stdin.readline
+from collections import deque
+
+def bfs():
+    q = deque()
+    q.append([0, 0, 1])
+    visited = [[[0, 0] for _ in range(m)] for _ in range(n)]
+    visited[0][0][1] = 1
+    while q:
+        x, y, key = q.popleft()
+        if x == n - 1 and y == m - 1:
+            return visited[x][y][key]
+        for dx, dy in delta:
+            nx, ny = x + dx, y + dy
+            if 0 <= nx < n and 0 <= ny < m:
+                # 벽이있고 뚫을 능력이 있을때.
+                if maze[nx][ny] == 1 and key == 1:
+                    visited[nx][ny][0] = visited[x][y][1] + 1
+                    q.append([nx, ny, 0])
+                # 벽이 없고 가보지 않은 곳.
+                elif maze[nx][ny] == 0 and visited[nx][ny][key] == 0:
+                    visited[nx][ny][key] = visited[x][y][key] + 1
+                    q.append([nx, ny, key])
+    return -1
+
+
+n, m = map(int, input().split())
+maze = [list(map(int, list(input().strip()))) for _ in range(n)]
+
+delta = ((0, 1), (1, 0), (0, -1), (-1, 0))
+
+print(bfs())

--- a/BOJ/dijkstra/01238-파티/01238-파티-seungjoo.py
+++ b/BOJ/dijkstra/01238-파티/01238-파티-seungjoo.py
@@ -1,1 +1,37 @@
 # git commit -m "code: Solve boj 01238 파티 (seungjoo)"
+import sys
+input = sys.stdin.readline
+from heapq import heappush, heappop
+
+def dijkstra(start, dist, graph):
+    heap = []
+    dist[start] = 0
+    heappush(heap, [0, start])
+    while heap:
+        cur_cost, cur_node = heappop(heap)
+        if dist[cur_node] < cur_cost:
+            continue
+        for next_node, next_cost in graph[cur_node]:
+            costs = next_cost + cur_cost
+            if costs < dist[next_node]:
+                dist[next_node] = costs
+                heappush(heap, [costs, next_node])
+
+n, m, x = map(int, input().split())
+
+graph = {i: [] for i in range(1, n + 1)}
+reverse_graph = {i: [] for i in range(1, n + 1)}
+for i in range(m):
+    a, b, t = map(int, input().split())
+    graph[a].append([b, t])
+    reverse_graph[b].append([a, t])
+
+dist = [float('inf')] * (n + 1)
+reverse_dist = [float('inf')] * (n + 1)
+dijkstra(x, dist, graph)
+dijkstra(x, reverse_dist, reverse_graph)
+
+max_dist = 0
+for i in range(1, n + 1):
+    max_dist = max(max_dist, dist[i] + reverse_dist[i])
+print(max_dist)


### PR DESCRIPTION
## ✏ Problems

- [x] 1238	파티
- [x] 2206	벽 부수고 이동하기

<br />
<br />

## 💡 Idea & Algorithm <!-- 핵심 아이디어 및 알고리즘 -->
### 파티
왕복은 정, 역방향 두가지를 그려주면 됩니다. 역방향이 되돌아오는 최단거리기 때문.

### 벽 부수고 이동하기
상태값은 다차원 배열로 저장합니다. 일종의 dp입니다. 

<br />
<br />

## ⏰ Efficiency <!-- 성능(시간) -->

- 00ms (Python3)

<br />
<br />

## 💬 Comment <!-- 후기 -->

벽뿌이는 시리즈 4까진가 있는데 모두 풀어보면 좋습니다.