### PR TITLE
21.12.12 (yoonbaek)

### DIFF
--- a/BOJ/bfs/02206-벽_부수고_이동하기/02206-벽_부수고_이동하기-yoonbaek.go
+++ b/BOJ/bfs/02206-벽_부수고_이동하기/02206-벽_부수고_이동하기-yoonbaek.go
@@ -1,1 +1,107 @@
-# git commit -m "code: Solve boj 02206 벽 부수고 이동하기 (yoonbaek)"
+// // git commit -m "code: Solve boj 02206 벽 부수고 이동하기 (yoonbaek)"
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+)
+
+var (
+	sc                = bufio.NewScanner(os.Stdin)
+	N, M              int
+	arr               [][]int
+	broken, notBroken [][]bool
+	moves             = []loc{{0, -1}, {0, 1}, {-1, 0}, {1, 0}}
+)
+
+func init() { sc.Split(bufio.ScanWords) }
+
+// utils
+func scan() int {
+	sc.Scan()
+	n, _ := strconv.Atoi(sc.Text())
+	return n
+}
+
+func scanLine() []int {
+	sc.Scan()
+	row := make([]int, M)
+	for i, b := range sc.Text() {
+		row[i] = int(b - 48)
+	}
+	return row
+}
+
+// code
+type loc struct{ row, col int }
+
+type hero struct {
+	loc
+	steps int
+	broke bool
+}
+
+type Queue chan hero
+
+func (q *Queue) push(h hero) { *q <- h }
+
+func (q *Queue) pop() hero { return <-*q }
+
+func outRange(x, N int) bool { return N <= x || x < 0 }
+
+func bfs(start hero) int {
+	q := make(Queue, N*M)
+	q.push(start)
+
+	for len(q) > 0 {
+		now := q.pop()
+
+		if now.row == N-1 && now.col == M-1 {
+			return now.steps
+		}
+
+		for _, move := range moves {
+			row, col, steps, broke := now.row+move.row, now.col+move.col, now.steps+1, now.broke
+			if outRange(row, N) || outRange(col, M) {
+				continue
+			}
+			switch arr[row][col] {
+			case 0:
+				if !broke && !notBroken[row][col] {
+					notBroken[row][col] = true
+					q.push(hero{loc{row, col}, steps, broke})
+					continue
+				}
+				if broke && !broken[row][col] {
+					broken[row][col] = true
+					q.push(hero{loc{row, col}, steps, broke})
+				}
+			case 1:
+				if !broke {
+					q.push(hero{loc{row, col}, steps, !broke})
+					broken[row][col] = true
+				}
+			}
+		}
+	}
+	return -1
+}
+
+func main() {
+	N, M = scan(), scan()
+	arr = make([][]int, N)
+	for row := 0; row < N; row++ {
+		arr[row] = scanLine()
+	}
+	notBroken = make([][]bool, N)
+	broken = make([][]bool, N)
+	for i := range notBroken {
+		notBroken[i] = make([]bool, M)
+		broken[i] = make([]bool, M)
+	}
+	start := hero{loc{0, 0}, 1, false}
+	fmt.Println(bfs(start))
+}

--- a/BOJ/dijkstra/01238-파티/01238-파티-yoonbaek.go
+++ b/BOJ/dijkstra/01238-파티/01238-파티-yoonbaek.go
@@ -1,1 +1,101 @@
-# git commit -m "code: Solve boj 01238 파티 (yoonbaek)"
+// git commit -m "code: Solve boj 01238 파티 (yoonbaek)"
+
+package main
+
+import (
+	"bufio"
+	"container/heap"
+	"fmt"
+	"os"
+	"strconv"
+)
+
+const INF = 100*10000 + 1
+
+var (
+	sc                     = bufio.NewScanner(os.Stdin)
+	N, M, X, start, end, T int
+)
+
+//utils
+func scan() int {
+	sc.Scan()
+	n, _ := strconv.Atoi(sc.Text())
+	return n
+}
+
+// heap interface
+type PriorityQueue []*Edge
+
+func (p PriorityQueue) Len() int { return len(p) }
+
+func (p PriorityQueue) Swap(i, j int) { p[i], p[j] = p[j], p[i] }
+
+func (p PriorityQueue) Less(i, j int) bool { return p[i].T < p[j].T }
+
+func (p *PriorityQueue) Push(i interface{}) { *p = append(*p, i.(*Edge)) }
+
+func (p *PriorityQueue) Pop() interface{} {
+	tmp := *p
+	pop := tmp[p.Len()-1]
+	*p = tmp[0 : p.Len()-1]
+	return pop
+}
+
+type Edge struct {
+	to int
+	T  int
+}
+
+func dijkstra(start int, graph [][]Edge) []int {
+	p := PriorityQueue{}
+	heap.Push(&p, &Edge{start, 0})
+
+	visited := make([]bool, N)
+	times := make([]int, N)
+
+	for i := 0; i < N; i++ {
+		times[i] = INF
+	}
+
+	for p.Len() > 0 {
+		now := heap.Pop(&p).(*Edge)
+		if visited[now.to] {
+			continue
+		}
+		visited[now.to] = true
+		for _, next := range graph[now.to] {
+			T := now.T + next.T
+			if times[next.to] > T {
+				times[next.to] = T
+				heap.Push(&p, &Edge{next.to, T})
+			}
+		}
+	}
+	return times
+}
+
+func main() {
+	sc.Split(bufio.ScanWords)
+	N, M, X = scan(), scan(), scan()-1
+	graph, reverse := make([][]Edge, N), make([][]Edge, N)
+	for i := 0; i < M; i++ {
+		start, end, T = scan()-1, scan()-1, scan()
+		graph[start] = append(graph[start], Edge{end, T})
+		reverse[end] = append(reverse[end], Edge{start, T})
+	}
+	toParty := dijkstra(X, graph)
+	toHome := dijkstra(X, reverse)
+
+	max := -1
+	for start := 0; start < N; start++ {
+		if start == X {
+			continue
+		}
+		cur := toParty[start] + toHome[start]
+		if cur > max {
+			max = cur
+		}
+	}
+	fmt.Println(max)
+}


### PR DESCRIPTION
## ✏ Problems

- [x] 01238 파티
- [x] 02206 벽 부수고 이동하기

<br />
<br />

## 💡 Idea & Algorithm <!-- 핵심 아이디어 및 알고리즘 -->
## 파티
다익스트라로 풀었습니다
처음에 모든 노드로 탐색해서 풀었는데
통과는 됐으나 너무 느려서 reverse로직을 따로 만들어서 풀었더니
450ms->8ms로 줄었습니다

## 벽뿌
푸는데 3시간 😭 
1부터 시작해야하고, 벽을 부순 여부에 따라 방문 여부를 구분해야 하는게
핵심이었는데 처음부터 깔끔하게 구현하는게 쉽진 않았습니다
<br />
<br />

## ⏰ Efficiency <!-- 성능(시간) -->

- 450ms -> 8ms (golang)
- 260ms
<br />
<br />

## 💬 Comment <!-- 후기 -->
