### PR TITLE
21.12.16 (yoonbaek)

### DIFF
--- a/BOJ/divide_and_conquer/02263-트리의_순회/02263-트리의_순회-yoonbaek.go
+++ b/BOJ/divide_and_conquer/02263-트리의_순회/02263-트리의_순회-yoonbaek.go
@@ -1,1 +1,71 @@
 // git commit -m "code: Solve boj 02263 트리의 순회 (yoonbaek)"
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+)
+
+var (
+	sc, wr             = bufio.NewScanner(os.Stdin), bufio.NewWriter(os.Stdout)
+	inOrder, postOrder []int
+	memo               map[int]int
+)
+
+// utils
+func scan() int {
+	sc.Scan()
+	n, _ := strconv.Atoi(sc.Text())
+	return n
+}
+
+// utils
+func printf(format string, i ...interface{}) {
+	fmt.Fprintf(wr, format, i...)
+}
+
+// input
+func getTree(N int) []int {
+	arr := make([]int, N)
+	for i := 0; i < N; i++ {
+		arr[i] = scan()
+	}
+	return arr
+}
+
+func toPreOrder(inStart, inEnd, postStart, postEnd int) {
+	/*
+		알아야 될 것.
+		1. 중위트리의 루트노드의 인덱스,
+		2. 후위트리의 왼쪽트리 크기
+	*/
+	if inStart > inEnd || postStart > postEnd {
+		return
+	}
+	curRoot := postOrder[postEnd]
+	printf("%d ", curRoot)
+	inOrderRoot := memo[curRoot]      // 1
+	leftSize := inOrderRoot - inStart // 2
+	toPreOrder(inStart, inOrderRoot-1, postStart, postStart+leftSize-1)
+	toPreOrder(inOrderRoot+1, inEnd, postStart+leftSize, postEnd-1)
+}
+
+// main
+func main() {
+	defer fmt.Println()
+	defer wr.Flush()
+
+	sc.Split(bufio.ScanWords)
+	N := scan()
+
+	inOrder = getTree(N)
+	postOrder = getTree(N)
+
+	memo = map[int]int{}
+	for i := 0; i < N; i++ {
+		memo[inOrder[i]] = i
+	}
+	toPreOrder(0, N-1, 0, N-1)
+}

--- a/BOJ/dp/09251-LCS/09251-LCS-yoonbaek.go
+++ b/BOJ/dp/09251-LCS/09251-LCS-yoonbaek.go
@@ -1,1 +1,52 @@
 // git commit -m "code: Solve boj 09251 LCS (yoonbaek)"
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+var (
+	sc            = bufio.NewScanner(os.Stdin)
+	first, second string
+)
+
+func scan() string {
+	sc.Scan()
+	return sc.Text()
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func LCS(i, j int, mem [][]int) {
+	if first[i] == second[j] {
+		mem[i+1][j+1] = mem[i][j] + 1
+		return
+	}
+	mem[i+1][j+1] = max(mem[i][j+1], mem[i+1][j])
+}
+
+func main() {
+	sc.Split(bufio.ScanLines)
+
+	first, second = scan(), scan()
+	F, S := len(first), len(second)
+	mem := make([][]int, F+1)
+	for row := range mem {
+		mem[row] = make([]int, S+1)
+	}
+
+	for row := range first {
+		for col := range second {
+			LCS(row, col, mem)
+		}
+	}
+
+	fmt.Println(mem[F][S])
+}

--- a/BOJ/dp/09251-LCS/09251-LCS-yoonbaek.go
+++ b/BOJ/dp/09251-LCS/09251-LCS-yoonbaek.go
@@ -10,6 +10,7 @@ import (
 var (
 	sc            = bufio.NewScanner(os.Stdin)
 	first, second string
+	maxLen        int
 )
 
 func scan() string {
@@ -17,36 +18,37 @@ func scan() string {
 	return sc.Text()
 }
 
-func max(a, b int) int {
-	if a > b {
-		return a
+func max(nums ...int) (max int) {
+	for _, num := range nums {
+		if max < num {
+			max = num
+		}
 	}
-	return b
+	return
 }
 
-func LCS(i, j int, mem [][]int) {
-	if first[i] == second[j] {
-		mem[i+1][j+1] = mem[i][j] + 1
+func LCS(i, j int, memo []int) {
+	if maxLen < memo[j] {
+		maxLen = memo[j]
 		return
 	}
-	mem[i+1][j+1] = max(mem[i][j+1], mem[i+1][j])
+	if first[i] == second[j] {
+		memo[j] = maxLen + 1
+	}
 }
 
 func main() {
 	sc.Split(bufio.ScanLines)
 
 	first, second = scan(), scan()
-	F, S := len(first), len(second)
-	mem := make([][]int, F+1)
-	for row := range mem {
-		mem[row] = make([]int, S+1)
-	}
+	memo := make([]int, len(second))
 
 	for row := range first {
+		maxLen = 0
 		for col := range second {
-			LCS(row, col, mem)
+			LCS(row, col, memo)
 		}
 	}
 
-	fmt.Println(mem[F][S])
+	fmt.Println(max(memo...))
 }


### PR DESCRIPTION
## ✏ Problems

- [x] 9251 LCS
- [x] 2263 트리의 순회

<br />
<br />

## 💡 Idea & Algorithm <!-- 핵심 아이디어 및 알고리즘 -->
## LCS
끊겨도 순서만 맞으면 부분수열에 포함된다는 걸 알아야 풀 수 있는 문제
## 트리의 순회
트리 그려가면서 풀면서 오랜만에 in/pre/post order 복습
<br />
<br />

## ⏰ Efficiency <!-- 성능(시간) -->

## LCS
- 20ms -> 8ms refac
## 트리의 순회
- 104ms (golang)

<br />
<br />

## 💬 Comment <!-- 후기 -->
트리의 순회 index out of range로 계속 고생했는데 결국 해결 못하고
다 갈아 엎고 slice 대신 크기가 정해진 array로 인풋 다시 받아서 풀었더니 해결 ㅠㅠ
먼저 golang으로 푸신 분들이 사이즈를 max로 놓더라도 slice 대신 array로 푸신 이유가 있네요

정확한 이유는 모르겠는데 strings.Split(sth, " " )로 풀었다가 안 풀린거 보면 실제로는 메모리에 할당이 안 된 공간에 인풋값을 집어넣으려고 했던거 같습니다.

앞으로는 맘 편하게 make로 미리 만들어주고 그 자리에 데이터 하나하나 집어넣어주는 걸로...!