### PR TITLE
21.12.16 (seungkyu)

### DIFF
--- a/BOJ/divide_and_conquer/02263-트리의_순회/02263-트리의_순회-seungkyu.py
+++ b/BOJ/divide_and_conquer/02263-트리의_순회/02263-트리의_순회-seungkyu.py
@@ -1,1 +1,29 @@
 # git commit -m "code: Solve boj 02263 트리의 순회 (seungkyu)"
+import sys
+input = sys.stdin.readline
+sys.setrecursionlimit(10**6)
+
+def preorder(in_start, in_end, post_start, post_end):
+    if in_start > in_end or post_start > post_end:
+        return
+    
+    # 루트는 post에서 마지막 원소
+    root = postorders[post_end]
+    print(root, end=' ')
+    pos = position[root]
+    left = pos-in_start
+
+    preorder(in_start, pos-1, post_start, post_start+left-1)
+    preorder(pos+1, in_end, post_start+left, post_end-1)
+
+
+n = int(input())
+inorders = list(map(int, input().split()))
+postorders = list(map(int, input().split()))
+position = [0]*100001
+
+# 시간 초과 안나도록 미리 찾아놓기
+for i in range(n):
+    position[inorders[i]] = i
+
+preorder(0, n-1, 0, n-1)

--- a/BOJ/dp/09251-LCS/09251-LCS-seungkyu.py
+++ b/BOJ/dp/09251-LCS/09251-LCS-seungkyu.py
@@ -1,1 +1,17 @@
 # git commit -m "code: Solve boj 09251 LCS (seungkyu)"
+import sys
+input = sys.stdin.readline
+
+a = input().strip()
+b = input().strip()
+
+dp = [[0]*(len(a)+1) for _ in range(len(b)+1)]
+
+for i in range(len(b)):
+    for j in range(len(a)):
+        if b[i] == a[j]:
+            dp[i+1][j+1] += dp[i][j] + 1
+        else:
+            dp[i+1][j+1] = max(dp[i][j+1], dp[i+1][j])
+            
+print(dp[len(b)][len(a)])


### PR DESCRIPTION
## ✏ Problems

- [x] 2263 트리의 순회
- [x] 9251 LCS


<br />
<br />

## 💡 Idea & Algorithm <!-- 핵심 아이디어 및 알고리즘 -->

### 트리의 순회
- 분할정복
- postorder에서 마지막 부분이 root이고, inorder에서 root를 기준으로 나눈 뒤 분할정복하는 과정(규칙을 바로 찾지는 못했었습니다.)

### LCS
- 2차원 배열을 만들어서 dp

<br />
<br />

## ⏰ Efficiency <!-- 성능(시간) -->

- 트리의 순회: 328ms (Python3)
- LCS: 776ms (Python3)

<br />
<br />

## 💬 Comment <!-- 후기 -->
